### PR TITLE
Ticket #3: New Function PWR_ObjGetSizeName

### DIFF
--- a/ChangeLog.tex
+++ b/ChangeLog.tex
@@ -1,8 +1,6 @@
 The following list contains changes to the community Power API specification version 2.1
 \begin{itemize}
-  \item{PWR_ObjGetName - Changed length input to a input/output and added text explaining how it can be used.
-         len now returns the length of the buffer returned or the length of the buffer that is needed if 
-         truncation has occurred. This allows for easier use of the function as the application can then call PWR_ObjGetName again with the correct length buffer.}
+  \item{PWR_ObjGetSizeName - New function added that allows the user to get the size of buffer required to successfully call PWR_ObjGetName for a given object.}
 
 \end{itemize}
 

--- a/ChangeLog.tex
+++ b/ChangeLog.tex
@@ -1,3 +1,12 @@
+The following list contains changes to the community Power API specification version 2.1
+\begin{itemize}
+  \item{PWR_ObjGetName - Changed length input to a input/output and added text explaining how it can be used.
+         len now returns the length of the buffer returned or the length of the buffer that is needed if 
+         truncation has occurred. This allows for easier use of the function as the application can then call PWR_ObjGetName again with the correct length buffer.}
+
+\end{itemize}
+
+
 The following list contains changes to version 2.0 of the specification.
 \begin{itemize}
   \item{PWR_StatusCreate - Added a context input parameter and clarified that statuses are cleared when used as an input to a function, therefore they should be checked prior to reuse, and caution should be taken when sharing statuses between threads.}

--- a/ChangeLog.tex
+++ b/ChangeLog.tex
@@ -1,6 +1,6 @@
 The following list contains changes to the community Power API specification version 2.1
 \begin{itemize}
-  \item{PWR_ObjGetSizeName - New function added that allows the user to get the size of buffer required to successfully call PWR_ObjGetName for a given object.}
+  \item{PWR_ObjGetSizeOfName - New function added that allows the user to get the size of buffer required to successfully call PWR_ObjGetName for a given object.}
 
 \end{itemize}
 

--- a/Common.tex
+++ b/Common.tex
@@ -123,15 +123,26 @@ This design choice was made in order to keep usage of the Power API as simple as
 %=============================================================================%
 %int    PWR_ObjGetName( PWR_Obj object, char* dest, size_t len );
 \begin{prototype}{ObjGetName}
-	\longdescription{The \texttt{PWR_ObjGetName} function copies the name of the specified object into the user provided buffer.  The len parameter will contain the length of the name of the specified object including any string terminators upon return. If the name is truncated, a warning will be returned and the value of the len parameter will be the length of the buffer required for a successful \texttt{PWR_ObjGetName} call.  See page \pageref{func:CntxtGetObjByName} to get the object based on the unique name using \texttt{PWR_CntxtGetObjByName}.}
+	\longdescription{The \texttt{PWR_ObjGetName} function copies the name of the specified object into the user provided buffer. See page \pageref{func:CntxtGetObjByName} to get the object based on the unique name using \texttt{PWR_CntxtGetObjByName}.}
 	\returntype{int}
 	\parameter{PWR_Obj object}	{\pInput}	{The object that the user wishes to determine the name of.}
 	\parameter{char* dest}    	{\pInput}	{The address of the user provided buffer.}
-	\parameter{size_t* len}    	{\pInputOutput}	{The length of the user provided buffer.}
+	\parameter{size_t len}    	{\pInput}	{The length of the user provided buffer.}
 	\returnval{PWR_RET_SUCCESS} 	{Upon SUCCESS, the buffer will contain the name of the object, the string will include a terminating null byte.}	
 	\returnval{PWR_RET_WARN_TRUNC} 	{Call succeeded, but the length of object name was longer than the provided buffer and the name was truncated.}
 	\returnval{PWR_RET_FAILURE} 	{Upon FAILURE.}
 \end{prototype}
+%=============================================================================%
+%int    PWR_ObjGetSizeName( PWR_Obj object, size_t len );
+\begin{prototype}{ObjGetSizeName}
+    \longdescription{The \texttt{PWR_ObjGetSizeName} returns the length of an object's name.  The len parameter will contain the length of the name of the specified object including any string terminators upon return. See page \pageref{func:CntxtGetObjByName} to get the object based on the unique name using \texttt{PWR_CntxtGetObjByName}.}
+    \returntype{int}
+    \parameter{PWR_Obj object}  {\pInput}   {The object that the user wishes to determine the name of.}
+    \parameter{size_t* len}     {\pInputOutput} {The length of the user provided buffer.}
+    \returnval{PWR_RET_SUCCESS}     {Upon SUCCESS, the len parameter will contain the size of buffer required to successfully call \texttt{PWR_ObjGetName}, including terminating null byte.}
+    \returnval{PWR_RET_FAILURE}     {Upon FAILURE.}
+\end{prototype}
+
 %==============================================================================%
 %int PWR_ObjGetParent( PWR_Obj object, PWR_Obj* parent );
 \begin{prototype}{ObjGetParent}

--- a/Common.tex
+++ b/Common.tex
@@ -133,9 +133,9 @@ This design choice was made in order to keep usage of the Power API as simple as
 	\returnval{PWR_RET_FAILURE} 	{Upon FAILURE.}
 \end{prototype}
 %=============================================================================%
-%int    PWR_ObjGetSizeName( PWR_Obj object, size_t len );
-\begin{prototype}{ObjGetSizeName}
-    \longdescription{The \texttt{PWR_ObjGetSizeName} returns the length of an object's name.  The len parameter will contain the length of the name of the specified object including any string terminators upon return. See page \pageref{func:CntxtGetObjByName} to get the object based on the unique name using \texttt{PWR_CntxtGetObjByName}.}
+%int    PWR_ObjGetSizeOfName( PWR_Obj object, size_t len );
+\begin{prototype}{ObjGetSizeOfName}
+    \longdescription{The \texttt{PWR_ObjGetSizeOfName} returns the length of an object's name.  The len parameter will contain the length of the name of the specified object including any string terminators upon return. See page \pageref{func:CntxtGetObjByName} to get the object based on the unique name using \texttt{PWR_CntxtGetObjByName}.}
     \returntype{int}
     \parameter{PWR_Obj object}  {\pInput}   {The object that the user wishes to determine the name of.}
     \parameter{size_t* len}     {\pInputOutput} {The length of the user provided buffer.}

--- a/Common.tex
+++ b/Common.tex
@@ -123,11 +123,11 @@ This design choice was made in order to keep usage of the Power API as simple as
 %=============================================================================%
 %int    PWR_ObjGetName( PWR_Obj object, char* dest, size_t len );
 \begin{prototype}{ObjGetName}
-	\longdescription{The \texttt{PWR_ObjGetName} function copies the name of the specified object into the user provided buffer.  See page \pageref{func:CntxtGetObjByName} to get the object based on the unique name using \texttt{PWR_CntxtGetObjByName}.}
+	\longdescription{The \texttt{PWR_ObjGetName} function copies the name of the specified object into the user provided buffer.  The len parameter will contain the length of the name of the specified object including any string terminators upon return. If the name is truncated, a warning will be returned and the value of the len parameter will be the length of the buffer required for a successful \texttt{PWR_ObjGetName} call.  See page \pageref{func:CntxtGetObjByName} to get the object based on the unique name using \texttt{PWR_CntxtGetObjByName}.}
 	\returntype{int}
 	\parameter{PWR_Obj object}	{\pInput}	{The object that the user wishes to determine the name of.}
 	\parameter{char* dest}    	{\pInput}	{The address of the user provided buffer.}
-	\parameter{size_t len}    	{\pInput}	{The length of the user provided buffer.}
+	\parameter{size_t* len}    	{\pInputOutput}	{The length of the user provided buffer.}
 	\returnval{PWR_RET_SUCCESS} 	{Upon SUCCESS, the buffer will contain the name of the object, the string will include a terminating null byte.}	
 	\returnval{PWR_RET_WARN_TRUNC} 	{Call succeeded, but the length of object name was longer than the provided buffer and the name was truncated.}
 	\returnval{PWR_RET_FAILURE} 	{Upon FAILURE.}


### PR DESCRIPTION
Code alternatives with keeping vs ditching truncation warning:
Without Warning:

```
int len = 25 * sizeof(char);
char* name = malloc(len);
int len_return;
do {
    ret = PWR_ObjGetName(obj, name, &len_return)
    if (PWR_SUCCESS != ret) abort;
    if (len_return > len) {
        free(name);
        char* name = malloc(len_return);
    }
} while len_return > len;
```
With Warning:

```
char* name = malloc (25 * sizeof(char));
int done, len = 0;
do {
    ret = PWR_ObjGetName(obj, name, &len);
    if (PWR_FAILURE == ret) {abort};
    else if (PWR_RET_WARN_TRUNC == ret) {
        free(name);
        char * name = malloc(len);
    } else {
        continue;
    }
} while 1;
```

SLOC count:

without warning: 11
with warning: 9
